### PR TITLE
Patch init version in manifest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,10 @@ WORKDIR /opt/al_service
 # Copy service code
 COPY . .
 
+# Patch version in manifest
+ARG version=4.0.0.dev1
+USER root
+RUN sed -i -e "s/\$SERVICE_TAG/$version/g" service_manifest.yml
+
 # Switch to assemblyline user
 USER assemblyline


### PR DESCRIPTION
Relating to: https://cccs.atlassian.net/browse/AL-1168

Dockerfile was missing a version patch in manifest. So upon registration from docker-compose in appliance, it would default to dev0 and scaler would attempt to pull that version (which doesn't exist).